### PR TITLE
Fix print function.

### DIFF
--- a/bios.lua
+++ b/bios.lua
@@ -166,8 +166,8 @@ end
 
 function print( ... )
     local nLinesPrinted = 0
-    for n,v in ipairs( { ... } ) do
-        nLinesPrinted = nLinesPrinted + write( tostring( v ) )
+    for n = 1, select('#', ... ) do
+        nLinesPrinted = nLinesPrinted + write( tostring( select( n, ... ) ) )
     end
     nLinesPrinted = nLinesPrinted + write( "\n" )
     return nLinesPrinted


### PR DESCRIPTION
If in the middle of vararg there was a nil, the print was stopping printing which is against Lua API.
